### PR TITLE
fixed bannerimage stretch

### DIFF
--- a/src/app/anime/[slug]/watch/page.tsx
+++ b/src/app/anime/[slug]/watch/page.tsx
@@ -48,7 +48,7 @@ async function page({ params, searchParams }: Props) {
             "https://image.tmdb.org/t/p/original" +
             random(tmdbLogo.result.backdrops).file_path
           }
-          className="lg:h-[500px] h-[200px] w-full opacity-50"
+          className="lg:h-[500px] h-[200px] w-full opacity-50 object-cover"
         />
         {tmdbLogo.result?.logos.length > 0 && (
           <div className="absolute flex item-center justify-center top-1/4 lg:top-1/3 lg:right-20 lg:left-auto left-1/3 space-x-5">


### PR DESCRIPTION
I just added the tailwind class `object-cover` to fix some of the stretched banner images on the site.

here is an example of the improvement on https://www.kitsunee.me/anime/fireworks/watch

BEFORE:
![before](https://github.com/Dovakiin0/Kitsune/assets/102994583/1433f41d-5cf2-4f00-a008-fe2393b23397)

AFTER:
![after](https://github.com/Dovakiin0/Kitsune/assets/102994583/3d664787-e54e-438e-8a39-2ec865abfe46)
