### PR TITLE
Syntax error fix for next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,12 @@
 const withPWA = require("@ducanh2912/next-pwa").default({
   dest: "public",
 });
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
     domains: ["i.waifu.pics"],
   },
+  output: 'standalone',
 };
 
-module.exports = withPWA({
-  ...nextConfig,
-  output: 'standalone',
-});
+module.exports = withPWA(nextConfig);

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 const withPWA = require("@ducanh2912/next-pwa").default({
   dest: "public",
 });
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
@@ -8,8 +9,7 @@ const nextConfig = {
   },
 };
 
-module.exports = {
+module.exports = withPWA({
+  ...nextConfig,
   output: 'standalone',
-}
-
-module.exports = withPWA(nextConfig);
+});


### PR DESCRIPTION
output: 'standalone', in module.exports  was overwritten by nextConfig previously, can you help check whether this logic/syntax is correct.